### PR TITLE
Updates to 3d_reconstruction and follow_line environment

### DIFF
--- a/jderobot_assets/launch/f1_1_circuit.launch
+++ b/jderobot_assets/launch/f1_1_circuit.launch
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launch>
+  <!-- We resume the logic in empty_world.launch, changing only the name of the world to be launched -->
+  <include file="$(find gazebo_ros)/launch/empty_world.launch">
+    <arg name="world_name" value="f1_1_circuit.world"/> <!-- Note: the world_name is with respect to GAZEBO_RESOURCE_PATH environmental variable -->
+    <arg name="paused" value="false"/>
+    <arg name="use_sim_time" value="true"/>
+    <arg name="gui" value="true"/>
+    <arg name="headless" value="false"/>
+    <arg name="debug" value="false"/>
+    <arg name="verbose" default="false"/>
+  </include>  
+</launch>

--- a/jderobot_assets/worlds/kobuki_1_reconstruccion3d.world
+++ b/jderobot_assets/worlds/kobuki_1_reconstruccion3d.world
@@ -8,10 +8,10 @@
         <uri>model://sun</uri>
     </include>
     <light name='point_light1' type='point'>
-      <pose frame=''>2.3 -0.25 1 0 0 0</pose>
+      <pose frame=''>-3.0 -2.0 4.0 0 0 0</pose>
     </light>
     <light name='point_light2' type='point'>
-      <pose frame=''>2.3 0.25 1 0 0 0</pose>
+      <pose frame=''>-3.0 2.0 4.0 0 0 0</pose>
     </light>
     
     <!-- Pioneer2dx model -->


### PR DESCRIPTION
This is in reference to issue #41 
For the 3d_reconstruction exercise, the light sources are adjusted to a new place to brighten the objects in the world.

For the follow_line exercise, a new launch file is added. The user can have the choice to launch the simple dark(less computation power) or the bright one(high computation power).